### PR TITLE
Fixes incorrect argument order in call-interactively

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -993,8 +993,8 @@ the optionally passed STRATEGY without cycling otherwise."
   
   (interactive "*")
   (if scala-indent:use-cycle-indent
-      (call-interactively t 'scala-indent:cycle-indent-line)
-    (call-interactively t 'scala-indent:strategy-indent-line)))
+      (call-interactively 'scala-indent:cycle-indent-line t)
+    (call-interactively 'scala-indent:strategy-indent-line t)))
 
 (defun scala-indent:indent-with-reluctant-strategy ()
   (interactive "*")


### PR DESCRIPTION
Fixes the call-interactively wrong type argument error in scala-indent:indent-line. `<TAB>` now works as intended.