### PR TITLE
Add explicit requires

### DIFF
--- a/scala-mode-imenu.el
+++ b/scala-mode-imenu.el
@@ -4,6 +4,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (require 'scala-mode-syntax)
 
 ;; Make lambdas proper clousures (only in this file)

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -2,6 +2,8 @@
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 
+(require 'thingatpt)
+
 (require 'scala-mode-syntax)
 (require 'scala-mode-lib)
 


### PR DESCRIPTION
Explicitly require the things from the emacs distribution that we require so that the byte-compiler doesn't warn us that they are missing