### PR TITLE
Various indentation fixes: typos, differentiating new lines, support for `do` and `extension`

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -250,7 +250,9 @@ and the empty line")
   (regexp-opt '("abstract" "catch" "case" "class" "def" "do" "else" "final"
                 "finally" "for" "if" "implicit" "import" "lazy" "new" "object"
                 "override" "package" "private" "protected" "return" "sealed"
-                "throw" "trait" "try" "type" "val" "var" "while" "yield" "inline")
+                "throw" "trait" "try" "type" "val" "var" "while" "yield" "inline"
+                "extension"
+                )
               'words)
   "Words that we don't want to continue the previous line")
 
@@ -438,6 +440,13 @@ Returns point or (point-min) if not inside a block."
     ;; <dot chaining>
     (`(?\n ?.) 'dot-chain)
     (`(?\n ?. . ,_) 'dot-chain)
+    ;; extension
+    ;;
+    ;; FIXME: This is a hack that just checks if the previous line contains
+    ;; extension.  The check for extension should check whether this is a
+    ;; single-def extension and for balanced parentheses, etc. to determine
+    ;; whether we emit a block token.
+    ((and `(extension . ,tail) (guard (memq ?\n tail))) 'block)
     ;; =
     (`(= ?\n . ,_) 'decl-lhs)
     ((and `(= ,_ . ,tail) (guard (memq ?\n tail))) 'after-decl)

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -756,7 +756,10 @@ certain amount of incorrect or in-progress syntactic forms."
              (setq point (nth 2 x))
              t)
       (setq analysis (scala-indent:analyze-context point stack))
-      (setq syntax-elem (cons (nth 0 analysis) syntax-elem))
+      (setq syntax-elem
+	    (if (nth 0 analysis)
+		(cons (nth 0 analysis) syntax-elem)
+	      syntax-elem))
       (setq ctxt-line (nth 1 analysis))
       (setq ctxt-indent (nth 2 analysis))
       (setq prev-indent (nth 3 analysis))

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -653,7 +653,7 @@ Returns point or (point-min) if not inside a block."
           (setq last-indentation (current-indentation))
           (while (looking-at-p "\\.") (backward-char))
           ;; ")." is a funny case where we actually do want to be on the dot
-          (if (looking-at-p ")") (forwar-char))
+          (if (looking-at-p ")") (forward-char))
           (scala-syntax:backward-sexp-forcing)))
       (let* ((x (or (scala-indent:skip-back-over-modifiers (point) stack)
                     (list (point) stack)))

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -537,7 +537,7 @@ Returns point or (point-min) if not inside a block."
     (`(decl else) -2)
     (`(decl . ,_) 2)
     ;; decl-lhs
-    (`(decl-lhs decl . ,_) 0)
+    (`(decl-lhs decl . ,_) 2)
     (`(decl-lhs dot-chain) 4)
     (`(dot-chain dot-chain) 0)
     (`(decl-lhs for-comp) 0)

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -434,7 +434,7 @@ Returns point or (point-min) if not inside a block."
     ;; <hitting the beginning of a block when starting in the middle> { (
     (`(?\{) 'left-boundary) ;; too aggressive?
     (`(?\{ ,_ . ,_) 'left-boundary)
-    (`(?\( ,_ . ,_) 'left-boundary)
+    ; (`(?\( ,_ . ,_) 'left-boundary)
     ;; <dot chaining>
     (`(?\n ?.) 'dot-chain)
     (`(?\n ?. . ,_) 'dot-chain)

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -372,7 +372,7 @@ is not on a run-on line."
           "\\|:\\("  scala-syntax:after-reserved-symbol-re "\\)"))
 
 (defconst scala-indent:forms-align-re
-  (regexp-opt '("yield" "then" "else" "catch" "finally") 'words))
+  (regexp-opt '("do" "yield" "then" "else" "catch" "finally") 'words))
 
 (defun scala-indent:forms-align-p (&optional point)
   "Returns `scala-syntax:beginning-of-code-line' for the line on
@@ -520,6 +520,7 @@ Returns point or (point-min) if not inside a block."
     (`(with) 'block)
     ;; yield
     (`(yield . ,_) 'yield-from-comp)
+    (`(do . ,_) 'yield-from-comp)
     ))
 
 (defun scala-indent:relative-indent-by-elem (syntax-elem)

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -746,10 +746,17 @@ tokenization. The parser is not anything like well-formalized, but it can start
 at an arbitrary point in the buffer, and except in pathological cases, look at
 relatively few lines in order to make a good guess; and it is tolerant to a
 certain amount of incorrect or in-progress syntactic forms."
-  (let* ((initResult (scala-indent:find-analysis-start point))
+  (let* ((line-no
+          ;; Get the line number while taking blanks into account.  This allows
+          ;; differentiating between indenting at a blank line and re-indenting
+          ;; at the line right before it.
+          (line-number-at-pos
+           (save-excursion
+             (when point (goto-char point))
+             (point))))
+         (initResult (scala-indent:find-analysis-start point))
          (point (car initResult))
          (stack (cadr initResult))
-         (line-no (line-number-at-pos point))
          (analysis (scala-indent:analyze-context point stack))
          (syntax-elem (list (nth 0 analysis)))
          (ctxt-line (nth 1 analysis))


### PR DESCRIPTION
This PR contains the following fixes to support Scala 3 indentation (numbers 2 and 3 made it way more usable in my experience):

1. Some fixes with propagation of nil values and typos.
2. Disabling emitting the `left-boundary` token when encountering a left paren: `(`. This turned out to be too aggressive when the indentation engine needs to look past an open paren to hit a token like `class`, `case` and so on.
3. Distinguishing blank lines and the previous non-blank line. This allows proper indentation when hitting return after a class declaration, etc.
4. Adding some support for indenting `do` and `extension` keywords properly:
  - `do` is treated just like `yield` (or `then`) because there are no more do..while loops in Scala.
  -  `extension` needs to be handled specially because extension blocks don't start with a `:` or `=` (unlike classes or declarations). Current implementation uses a rough heuristic (observing `extension` and an occurrence of a newline).

There are still some fixes that need to be made (I can move this bit to https://github.com/hvesalai/emacs-scala-mode/issues/160):
- I haven't looked at using the cycling behavior. So far, I have focused on making a good initial guess.
- There is no support for the `end` keyword. The simplest approach would be to make it reduce indentation by one level, but there are variants like `end if`, `end foo` which should scan for the corresponding unclosed block.
- There is an edge case for when re-indenting the statement after the end of a block. Current heuristics assume that this statement would be a continuation of the previous block (I included an example before). For comparison, `haskell-mode` does not change the indentation in this case.

Here is an example of the last thing I mentioned:

```scala
for x <- xs do
  print(x)
  for y <- x.bars do
    val x = print(y)
  print(s"end of $x")  // if we open a new line after this statement, the
                       // indentation heuristics indent both lines to align
                       // with print(y)

```

After this PR, I can focus on adding support for the `end` keyword, but solving the last problem would be a bit difficult (it is effectively trying to guess the user's intent). In my opinion, using cycling+a sane default would be the best option there.